### PR TITLE
Add new agent/office fields to listing schema

### DIFF
--- a/lib/listing-desc.js
+++ b/lib/listing-desc.js
@@ -116,8 +116,6 @@ module.exports = {
   associationName: 'The name of the Home Owners Association.',
   associationFee: 'A fee paid by the homeowner to the Home Owners Association which is used for the upkeep of the common area, neighborhood or other association related benefits.',
   associationFeeFrequency: 'The frequency the association fee is paid.  For example, Weekly, Monthly, Annually, Bi-Monthly, One Time, etc.',
-  listAgentName: 'The full name of the listing agent.',
-  listOfficeName: 'The legal name of the brokerage representing the seller.',
   listingAgentFirstName: 'The first name of the listing agent.',
   listingAgentLastName: 'The last name of the listing agent.',
   listingAgentMiddleName: 'The middle name of the listing agent.',

--- a/lib/listing-desc.js
+++ b/lib/listing-desc.js
@@ -118,5 +118,12 @@ module.exports = {
   associationFeeFrequency: 'The frequency the association fee is paid.  For example, Weekly, Monthly, Annually, Bi-Monthly, One Time, etc.',
   listAgentName: 'The full name of the listing agent.',
   listOfficeName: 'The legal name of the brokerage representing the seller.',
+  listingAgentFirstName: 'The first name of the listing agent.',
+  listingAgentLastName: 'The last name of the listing agent.',
+  listingAgentMiddleName: 'The middle name of the listing agent.',
+  listingAgentFullName: 'The full name of the listing agent. (First Middle Last)',
+  listingAgentPhone: 'The preferred phone number of the listing agent.',
+  listingOfficeName: 'The office name associated with the listing agent.',
+  listingOfficePhone: 'The office phone number associated with the listing agent.',
   url: 'URL to find details for the specific listing.'
 };

--- a/lib/listing-desc.js
+++ b/lib/listing-desc.js
@@ -116,5 +116,7 @@ module.exports = {
   associationName: 'The name of the Home Owners Association.',
   associationFee: 'A fee paid by the homeowner to the Home Owners Association which is used for the upkeep of the common area, neighborhood or other association related benefits.',
   associationFeeFrequency: 'The frequency the association fee is paid.  For example, Weekly, Monthly, Annually, Bi-Monthly, One Time, etc.',
+  listAgentName: 'The full name of the listing agent.',
+  listOfficeName: 'The legal name of the brokerage representing the seller.',
   url: 'URL to find details for the specific listing.'
 };

--- a/lib/listing.js
+++ b/lib/listing.js
@@ -117,6 +117,8 @@ var listingSchema = {
   associationName: {type: 'string'},
   associationFee: {type: 'number'},
   associationFeeFrequency: {type: 'string'},
+  listAgentName: {type: 'string'},
+  listOfficeName: {type: 'string'},
   url: {type: 'string'}
 };
 
@@ -231,7 +233,10 @@ var ddMap = {
   association: 'AssociationYN',
   associationName: 'AssociationName',
   associationFee: 'AssociationFee',
-  associationFeeFrequency: 'AssociationFeeFrequency'
+  associationFeeFrequency: 'AssociationFeeFrequency',
+
+  listAgentName: 'ListAgentFullName',
+  listOfficeName: 'ListOfficeName'
 };
 
 module.exports = addDescriptions(listingSchema, descriptions, ddMap);

--- a/lib/listing.js
+++ b/lib/listing.js
@@ -117,8 +117,13 @@ var listingSchema = {
   associationName: {type: 'string'},
   associationFee: {type: 'number'},
   associationFeeFrequency: {type: 'string'},
-  listAgentName: {type: 'string'},
-  listOfficeName: {type: 'string'},
+  listingAgentFirstName: {type: 'string'},
+  listingAgentLastName: {type: 'string'},
+  listingAgentMiddleName: {type: 'string'},
+  listingAgentFullName: {type: 'string'},
+  listingAgentPhone: {type: 'string'},
+  listingOfficeName: {type: 'string'},
+  listingOfficePhone: {type: 'string'},
   url: {type: 'string'}
 };
 
@@ -235,8 +240,13 @@ var ddMap = {
   associationFee: 'AssociationFee',
   associationFeeFrequency: 'AssociationFeeFrequency',
 
-  listAgentName: 'ListAgentFullName',
-  listOfficeName: 'ListOfficeName'
+  listingAgentFirstName: 'ListAgentFirstName',
+  listingAgentLastName: 'ListAgentLastName',
+  listingAgentMiddleName: 'ListAgentMiddleName',
+  listingAgentFullName: 'ListAgentFullName',
+  listingAgentPhone: 'ListAgentPreferredPhone',
+  listingOfficeName: 'ListOfficeName',
+  listingOfficePhone: 'ListOfficePhone',
 };
 
 module.exports = addDescriptions(listingSchema, descriptions, ddMap);


### PR DESCRIPTION
## Team

- @jkhwan
- @kregensberg 
- @EnFinlay 
- @CalvinScott 

## Overview

As requested by Dotloop, adding the agent name and office name onto the listings would allow them to reduce the number of api requests.

## Tasks

- [x] Add seven new fields

## Deployment

## Release

These changes are minor.
