### PR TITLE
Listing ddMap Typo

### DIFF
--- a/lib/listing.js
+++ b/lib/listing.js
@@ -220,8 +220,8 @@ var ddMap = {
   contingentDate: 'ContingentDate',
   withdrawnDate: 'WithdrawnDate',
   offMarketDate: 'OffMarketDate',
-  purchaseContractDate: 'OriginalEntryTimestamp',
-  originalEntryTimestamp: {type: 'date'},
+  purchaseContractDate: 'PurchaseContractDate',
+  originalEntryTimestamp: 'OriginalEntryTimestamp',
 
   taxAssessedValue: 'TaxAssessedValue',
   taxAnnual: 'TaxAnnualAmount',


### PR DESCRIPTION
# Overview

While working on improving RESO test data on the API, I noticed that there seems to be a typo on the listing ddMap object.

```
  purchaseContractDate: 'OriginalEntryTimestamp',
  originalEntryTimestamp: {type: 'date'},

  taxAssessedValue: 'TaxAssessedValue',
```

To my eyes, it looks like originalEntryTimestamp should just be 'OriginalEntryTimestamp' and purchaseContractDate should be 'PurchaseContractDate' (presumably).

# Tasks

- [x] Update the two fields accordingly

# Deployment

Release as **_patch_**

(Tentative - taken from another retsly-schemas issue)
- npm install and restart api
- npm install and build docs www
- npm install and restart import
